### PR TITLE
Fix: The Ornamental Pistol Unlockable ID

### DIFF
--- a/mod content/menus/item sorting/overridesminisorting/chunk0/PLEASEDONTBREAK.unlockables.json
+++ b/mod content/menus/item sorting/overridesminisorting/chunk0/PLEASEDONTBREAK.unlockables.json
@@ -929,7 +929,7 @@
         "OrderIndex": 341
     }
 },
-"EG_MASTERY_SKIN_LUXURIOUS_PISTOL":{
+"FIREARMS_HERO_PISTOL_BARTOLI_75_LUXURIOUS":{
     "Properties": {
         "OrderIndex": 351
     }


### PR DESCRIPTION
Fixed the Ornamental Pistol unlockable ID from Mastery Unlock (EG_MASTERY_SKIN_LUXURIOUS_PISTOL) to the actual pistol itself (FIREARMS_HERO_PISTOL_BARTOLI_75_LUXURIOUS)